### PR TITLE
fix: 영상 재생 불가 오류 수정

### DIFF
--- a/src/components/common/VideoPlayer.tsx
+++ b/src/components/common/VideoPlayer.tsx
@@ -59,7 +59,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     playDurationRef.current = 0;
 
     if (Hls.isSupported()) {
-      const hls = new Hls();
+      const hls = new Hls({
+        xhrSetup: (xhr) => {
+          xhr.withCredentials = true; // 쿠키 포함
+        },
+      });
       hls.loadSource(videoUrl);
       hls.attachMedia(video);
 

--- a/src/services/videoService.ts
+++ b/src/services/videoService.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import apiClient from "./apiClient";
 
 export interface VideoPlayInfo {
@@ -34,6 +35,16 @@ export const videoService = {
    */
   getPlayInfo: async (videoId: number | string): Promise<VideoPlayInfo> => {
     const response = await apiClient.get(`/api/contents/${videoId}/play`);
+
+    const { policy, signature, keyPairId } = response.data.data;
+
+    // CloudFront 자판기(/set-cookie)에 교환권을 내고 진짜 쿠키를 브라우저에 받습니다!
+    // 이 요청은 CloudFront로 직접 가기 때문에, 브라우저가 CloudFront 전용 쿠키로 아주 잘 저장합니다.
+    await axios.get(`https://dpfh72fut41hj.cloudfront.net/set-cookie`, {
+      params: { policy, signature, keyPairId },
+      withCredentials: true,
+    });
+
     return response.data.data;
   },
 


### PR DESCRIPTION
영상 재생이 불가한 현상이 있었습니다.

백엔드에서 CDN 을 적용함과 동시에 보안을 위해 signed cookie 방식을 선택했습니다.

이에 따라, 프론트에서도 동영상을 재생할 때, 

백엔드가 내려준 cookie 를 동영상 재생하면서 계속 보내야 합니다.
이 내용이 VideoPlayer.tsx 에서 Hls에 쿠키를 포함(withCredentials: true)하도록 설정한 내용입니다

---------------------------------------------------------------------------------------------------------------

또한 쿠키를 내려주려 했는데, API 서버와 CloudFront(CDN) 서버의 도메인이 달라 브라우저의 교차 출처(Cross-Domain) 보안 정책에 의해 쿠키가 정상적으로 브라우저에 저장되지 않고 차단되는 문제가 발생했습니다.

그래서 백엔드에서 직접 쿠키에 내용을 넣는게 아니라, json 에 서명 데이터를 포함시켜서 프론트로 내려주고,

그 값들을 CloudFront 내에 텍스트 데이터를 실제 쿠키로 변환해 주는 쿠키 발급 전용 라우터(/set-cookie) 에 보내서, 쿠키에 담도록 우회하였습니다.
이 내용이 videoService.ts 의 await.get( ... ) 부분입니다.


위 내용이 머지되고나면,
로그인 한 뒤에 101 번 콘텐츠 키시면 동영상 제대로 나옵니다.
나머지들은 실제 영상이 없어가지고 안나올겁니다.