### PR TITLE
feat(admin): 관리자 홈태그 통계 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.487.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.1",
@@ -508,6 +509,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -874,6 +911,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
@@ -1100,6 +1149,69 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1111,16 +1223,15 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1135,6 +1246,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.11.0",
@@ -1288,7 +1405,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1433,7 +1549,134 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -1525,6 +1768,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -1573,6 +1826,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1808,6 +2067,25 @@
       "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
       "license": "Apache-2.0"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1876,7 +2154,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2117,7 +2394,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2293,7 +2569,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2306,13 +2581,42 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {
@@ -2369,6 +2673,57 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -2587,6 +2942,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2628,7 +2989,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2701,6 +3061,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2708,13 +3077,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lucide-react": "^0.487.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.1",

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,3 +1,4 @@
+// AdminPage.tsx - 관리자 페이지 컴포넌트 
 import React, { useState, useEffect, useCallback } from "react";
 import {
   Users,
@@ -11,7 +12,10 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
+
+
 import { adminService } from "@/services/adminService";
+import Statistics from "./Statistics";
 import type { AdminUser, AdminUserDetail } from "@/types";
 import {
   formatDate,
@@ -589,152 +593,7 @@ const ContentsManagement: React.FC<{
   );
 };
 
-// 통계/분석 컴포넌트
-const Statistics: React.FC = () => {
-  // Mock 데이터
-  const popularContents = [
-    {
-      rank: 1,
-      title: "인기 영화 1",
-      views: 15000,
-      bookmarks: 3200,
-      completionRate: 85,
-    },
-    {
-      rank: 2,
-      title: "인기 드라마 1",
-      views: 12000,
-      bookmarks: 2800,
-      completionRate: 78,
-    },
-    {
-      rank: 3,
-      title: "인기 영화 2",
-      views: 10000,
-      bookmarks: 2500,
-      completionRate: 82,
-    },
-  ];
 
-  const tagStats = [
-    { tag: "액션", count: 5000, percentage: 25 },
-    { tag: "드라마", count: 4000, percentage: 20 },
-    { tag: "코미디", count: 3500, percentage: 17.5 },
-    { tag: "스릴러", count: 3000, percentage: 15 },
-    { tag: "로맨스", count: 2500, percentage: 12.5 },
-  ];
 
-  return (
-    <div className="space-y-8">
-      {/* 인기 차트 */}
-      <div>
-        <h2 className="text-2xl font-bold mb-4">인기 콘텐츠 순위</h2>
-        <div className="bg-gray-900 rounded-lg overflow-hidden">
-          <table className="w-full">
-            <thead className="bg-gray-800">
-              <tr>
-                <th className="px-6 py-3 text-left text-sm font-medium">
-                  순위
-                </th>
-                <th className="px-6 py-3 text-left text-sm font-medium">
-                  제목
-                </th>
-                <th className="px-6 py-3 text-left text-sm font-medium">
-                  조회수
-                </th>
-                <th className="px-6 py-3 text-left text-sm font-medium">
-                  찜하기
-                </th>
-                <th className="px-6 py-3 text-left text-sm font-medium">
-                  완료율
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-800">
-              {popularContents.map((content) => (
-                <tr
-                  key={content.rank}
-                  className="hover:bg-gray-800/50 transition-colors"
-                >
-                  <td className="px-6 py-4 text-sm">
-                    <span className="flex items-center justify-center w-8 h-8 bg-primary rounded-full font-bold">
-                      {content.rank}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm font-medium">
-                    {content.title}
-                  </td>
-                  <td className="px-6 py-4 text-sm">
-                    {content.views.toLocaleString()}
-                  </td>
-                  <td className="px-6 py-4 text-sm">
-                    {content.bookmarks.toLocaleString()}
-                  </td>
-                  <td className="px-6 py-4 text-sm">
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 bg-gray-800 rounded-full h-2 max-w-[100px]">
-                        <div
-                          className="bg-primary h-2 rounded-full"
-                          style={{ width: `${content.completionRate}%` }}
-                        ></div>
-                      </div>
-                      <span className="text-xs text-gray-400">
-                        {content.completionRate}%
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {/* 태그 통계 */}
-      <div>
-        <h2 className="text-2xl font-bold mb-4">선호 태그 통계</h2>
-        <div className="bg-gray-900 rounded-lg p-6">
-          <div className="space-y-4">
-            {tagStats.map((stat) => (
-              <div key={stat.tag}>
-                <div className="flex justify-between mb-2">
-                  <span className="font-medium">{stat.tag}</span>
-                  <span className="text-sm text-gray-400">
-                    {stat.count.toLocaleString()}회 ({stat.percentage}%)
-                  </span>
-                </div>
-                <div className="bg-gray-800 rounded-full h-3">
-                  <div
-                    className="bg-primary h-3 rounded-full transition-all"
-                    style={{ width: `${stat.percentage}%` }}
-                  ></div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* 통계 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-gray-900 rounded-lg p-6">
-          <h3 className="text-gray-400 text-sm mb-2">전체 사용자</h3>
-          <p className="text-3xl font-bold">1,234</p>
-          <p className="text-sm text-green-400 mt-2">↑ 12% 지난주 대비</p>
-        </div>
-        <div className="bg-gray-900 rounded-lg p-6">
-          <h3 className="text-gray-400 text-sm mb-2">전체 콘텐츠</h3>
-          <p className="text-3xl font-bold">567</p>
-          <p className="text-sm text-green-400 mt-2">↑ 8% 지난주 대비</p>
-        </div>
-        <div className="bg-gray-900 rounded-lg p-6">
-          <h3 className="text-gray-400 text-sm mb-2">총 시청 시간</h3>
-          <p className="text-3xl font-bold">45,678h</p>
-          <p className="text-sm text-green-400 mt-2">↑ 15% 지난주 대비</p>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 export default AdminPage;

--- a/src/pages/admin/Statistics.tsx
+++ b/src/pages/admin/Statistics.tsx
@@ -1,0 +1,613 @@
+import React, { useState, useMemo, useEffect } from "react";
+import {
+  BarChart3,
+  Search,
+  Bookmark,
+  Eye,
+  Trophy,
+  Filter,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+
+import { adminService } from "@/services/adminService";
+import type { HomeTagStatItem } from "@/services/adminService";
+
+type SortKey =
+  | "totalViewCount"
+  | "totalBookmarkCount"
+  | "bookmarkRate"
+  | "totalWatchCount"
+  | "completedWatchCount"
+  | "completionRate";
+
+type RankingTabKey = "views" | "bookmarkRate" | "completionRate";
+
+const Statistics: React.FC = () => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [selectedDate, setSelectedDate] = useState(today);
+  const [stats, setStats] = useState<HomeTagStatItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const [sortKey, setSortKey] = useState<SortKey>("totalViewCount");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [minWatchCount, setMinWatchCount] = useState<number>(0);
+
+  const [rankingTab, setRankingTab] = useState<RankingTabKey>("views");
+  const [showDetailTable, setShowDetailTable] = useState(false);
+
+  const loadStats = async () => {
+    setLoading(true);
+    try {
+      const data = await adminService.getHomeTagStats(selectedDate);
+      setStats(data);
+    } catch (error) {
+      console.error("홈 태그 통계 조회 실패:", error);
+      setStats([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadStats();
+  }, [selectedDate]);
+
+  const summary = useMemo(() => {
+    const totalViewCount = stats.reduce((sum, item) => sum + item.totalViewCount, 0);
+    const totalBookmarkCount = stats.reduce(
+      (sum, item) => sum + item.totalBookmarkCount,
+      0,
+    );
+    const totalWatchCount = stats.reduce((sum, item) => sum + item.totalWatchCount, 0);
+    const completedWatchCount = stats.reduce(
+      (sum, item) => sum + item.completedWatchCount,
+      0,
+    );
+
+    const avgBookmarkRate =
+      totalViewCount === 0 ? 0 : totalBookmarkCount / totalViewCount;
+
+    const avgCompletionRate =
+      totalWatchCount === 0 ? 0 : completedWatchCount / totalWatchCount;
+
+    return {
+      totalViewCount,
+      totalBookmarkCount,
+      totalWatchCount,
+      completedWatchCount,
+      avgBookmarkRate,
+      avgCompletionRate,
+    };
+  }, [stats]);
+
+  const filteredStats = useMemo(() => {
+    return stats.filter((item) => {
+      const matchesKeyword =
+        item.tagName.toLowerCase().includes(searchKeyword.toLowerCase());
+      const matchesWatchCount = item.totalWatchCount >= minWatchCount;
+      return matchesKeyword && matchesWatchCount;
+    });
+  }, [stats, searchKeyword, minWatchCount]);
+
+  const sortedStats = useMemo(() => {
+    return [...filteredStats].sort((a, b) => {
+      const aValue = a[sortKey] ?? 0;
+      const bValue = b[sortKey] ?? 0;
+      return Number(bValue) - Number(aValue);
+    });
+  }, [filteredStats, sortKey]);
+
+  const topViewTags = useMemo(() => {
+    return [...stats]
+      .sort((a, b) => b.totalViewCount - a.totalViewCount)
+      .slice(0, 5);
+  }, [stats]);
+
+  const topBookmarkRateTags = useMemo(() => {
+    return [...stats]
+      .filter((item) => item.totalViewCount > 0)
+      .sort((a, b) => b.bookmarkRate - a.bookmarkRate)
+      .slice(0, 5);
+  }, [stats]);
+
+  const topCompletionRateTags = useMemo(() => {
+    return [...stats]
+      .filter((item) => item.totalWatchCount > 0)
+      .sort((a, b) => b.completionRate - a.completionRate)
+      .slice(0, 5);
+  }, [stats]);
+
+  const chartData = useMemo(() => {
+    return [...stats]
+      .sort((a, b) => b.totalViewCount - a.totalViewCount)
+      .slice(0, 8)
+      .map((item) => ({
+        tagName: item.tagName,
+        totalViewCount: item.totalViewCount,
+      }));
+  }, [stats]);
+
+  const insight = useMemo(() => {
+    const topView = topViewTags[0];
+    const topBookmark = topBookmarkRateTags[0];
+    const topCompletion = topCompletionRateTags[0];
+
+    return {
+      topView,
+      topBookmark,
+      topCompletion,
+    };
+  }, [topViewTags, topBookmarkRateTags, topCompletionRateTags]);
+
+  const rankingItems = useMemo(() => {
+    if (rankingTab === "views") {
+      return topViewTags.map((item) => ({
+        tagName: item.tagName,
+        value: formatNumber(item.totalViewCount),
+      }));
+    }
+
+    if (rankingTab === "bookmarkRate") {
+      return topBookmarkRateTags.map((item) => ({
+        tagName: item.tagName,
+        value: formatRate(item.bookmarkRate),
+      }));
+    }
+
+    return topCompletionRateTags.map((item) => ({
+      tagName: item.tagName,
+      value: formatRate(item.completionRate),
+    }));
+  }, [rankingTab, topViewTags, topBookmarkRateTags, topCompletionRateTags]);
+
+  return (
+    <div className="space-y-6">
+      {/* 헤더 */}
+      <SectionCard>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold">홈 노출 태그 성과 대시보드</h2>
+            <p className="mt-2 text-sm text-gray-400">
+              홈 노출(priority=1) 태그의 성과 지표를 KPI 요약 → 태그별 비교 → 상세 분석 흐름으로 제공합니다.
+            </p>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-xs text-gray-400">기준 날짜</label>
+            <input
+              type="date"
+              value={selectedDate}
+              onChange={(e) => setSelectedDate(e.target.value)}
+              className="rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white"
+            />
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* KPI */}
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiCard
+          icon={<Eye className="h-5 w-5" />}
+          title="총 조회수"
+          value={formatNumber(summary.totalViewCount)}
+          description="홈 노출 태그 전체 조회수 합산"
+        />
+        <KpiCard
+          icon={<Bookmark className="h-5 w-5" />}
+          title="총 북마크"
+          value={formatNumber(summary.totalBookmarkCount)}
+          description="홈 노출 태그 전체 북마크 합산"
+        />
+        <KpiCard
+          icon={<BarChart3 className="h-5 w-5" />}
+          title="평균 북마크율"
+          value={formatRate(summary.avgBookmarkRate)}
+          description="총 북마크 ÷ 총 조회수"
+        />
+        <KpiCard
+          icon={<Trophy className="h-5 w-5" />}
+          title="평균 완료율"
+          value={formatRate(summary.avgCompletionRate)}
+          description="완료 시청 ÷ 총 시청"
+        />
+      </section>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      ) : (
+        <>
+          {/* 한 줄 인사이트 */}
+          <InsightBanner
+            topViewTag={insight.topView?.tagName}
+            topViewValue={
+              insight.topView ? formatNumber(insight.topView.totalViewCount) : "-"
+            }
+            topBookmarkTag={insight.topBookmark?.tagName}
+            topBookmarkValue={
+              insight.topBookmark ? formatRate(insight.topBookmark.bookmarkRate) : "-"
+            }
+            topCompletionTag={insight.topCompletion?.tagName}
+            topCompletionValue={
+              insight.topCompletion
+                ? formatRate(insight.topCompletion.completionRate)
+                : "-"
+            }
+          />
+
+          {/* Top Tags 탭 */}
+          <SectionCard>
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-lg font-semibold">Top Tags</h3>
+                <p className="text-sm text-gray-400">
+                  핵심 지표별 상위 5개 태그를 빠르게 비교합니다.
+                </p>
+              </div>
+            </div>
+
+            <TopRankingTabs
+              activeTab={rankingTab}
+              onChange={setRankingTab}
+              items={rankingItems}
+            />
+          </SectionCard>
+
+          {/* 차트 */}
+          <SectionCard>
+            <div className="mb-4">
+              <h3 className="text-lg font-semibold">태그 성과 차트</h3>
+              <p className="text-sm text-gray-400">
+                조회수 기준 상위 8개 태그를 비교합니다.
+              </p>
+            </div>
+
+            <div className="h-[340px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 12, right: 12, left: 0, bottom: 8 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                  <XAxis
+                    dataKey="tagName"
+                    stroke="#9CA3AF"
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis
+                    stroke="#9CA3AF"
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value) => formatCompactNumber(Number(value))}
+                  />
+                  <Tooltip
+                    formatter={(value) => [formatNumber(Number(value ?? 0)), "조회수"]}
+                    contentStyle={{
+                        backgroundColor: "#111827",
+                        border: "1px solid #374151",
+                        borderRadius: "12px",
+                        color: "#fff",
+                    }}
+                    cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                    />
+                  <Bar dataKey="totalViewCount" radius={[10, 10, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </SectionCard>
+
+          {/* 상세 데이터 */}
+          <SectionCard>
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">상세 데이터</h3>
+                <p className="text-sm text-gray-400">
+                  필요할 때만 펼쳐서 검색, 필터, 정렬 기준으로 상세 지표를 확인합니다.
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setShowDetailTable((prev) => !prev)}
+                className="inline-flex items-center gap-2 rounded-xl border border-gray-700 bg-gray-800 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-700"
+              >
+                {showDetailTable ? (
+                  <>
+                    상세 데이터 접기 <ChevronUp className="h-4 w-4" />
+                  </>
+                ) : (
+                  <>
+                    상세 데이터 보기 <ChevronDown className="h-4 w-4" />
+                  </>
+                )}
+              </button>
+            </div>
+
+            {showDetailTable && (
+              <div className="mt-6">
+                <div className="mb-5 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+                  <div className="flex flex-col gap-3 md:flex-row">
+                    <div className="relative">
+                      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                      <input
+                        value={searchKeyword}
+                        onChange={(e) => setSearchKeyword(e.target.value)}
+                        placeholder="태그 검색"
+                        className="w-full rounded-lg border border-gray-700 bg-gray-800 py-2 pl-10 pr-4 text-sm text-white md:w-[220px]"
+                      />
+                    </div>
+
+                    <div className="flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800 px-3 py-2">
+                      <Filter className="h-4 w-4 text-gray-400" />
+                      <input
+                        type="number"
+                        min={0}
+                        value={minWatchCount}
+                        onChange={(e) =>
+                          setMinWatchCount(Number(e.target.value) || 0)
+                        }
+                        className="w-20 bg-transparent text-sm text-white outline-none"
+                      />
+                      <span className="text-sm text-gray-400">최소 시청</span>
+                    </div>
+
+                    <select
+                      value={sortKey}
+                      onChange={(e) => setSortKey(e.target.value as SortKey)}
+                      className="rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white"
+                    >
+                      <option value="totalViewCount">조회수순</option>
+                      <option value="totalBookmarkCount">북마크순</option>
+                      <option value="bookmarkRate">북마크율순</option>
+                      <option value="totalWatchCount">시청순</option>
+                      <option value="completedWatchCount">완료순</option>
+                      <option value="completionRate">완료율순</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="overflow-x-auto rounded-xl border border-gray-800">
+                  <table className="w-full min-w-[920px]">
+                    <thead className="bg-gray-800">
+                      <tr>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">태그</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">조회수</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">북마크</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">북마크율</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">시청</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">완료</th>
+                        <th className="px-5 py-4 text-left text-sm font-semibold">완료율</th>
+                      </tr>
+                    </thead>
+
+                    <tbody className="divide-y divide-gray-800">
+                      {sortedStats.length === 0 ? (
+                        <tr>
+                          <td
+                            colSpan={7}
+                            className="px-5 py-12 text-center text-sm text-gray-400"
+                          >
+                            조건에 맞는 태그 데이터가 없습니다.
+                          </td>
+                        </tr>
+                      ) : (
+                        sortedStats.map((item, index) => (
+                          <tr
+                            key={item.tagId}
+                            className="transition-colors hover:bg-gray-800/50"
+                          >
+                            <td className="px-5 py-4 text-sm font-medium text-white">
+                              <div className="flex items-center gap-3">
+                                {index < 3 && (
+                                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-xs font-bold text-primary">
+                                    {index + 1}
+                                  </span>
+                                )}
+                                <span>{item.tagName}</span>
+                              </div>
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              {formatNumber(item.totalViewCount)}
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              {formatNumber(item.totalBookmarkCount)}
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              <RateBadge value={formatRate(item.bookmarkRate)} />
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              {item.totalWatchCount === 0 ? (
+                                <span className="text-gray-500">-</span>
+                              ) : (
+                                formatNumber(item.totalWatchCount)
+                              )}
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              {item.completedWatchCount === 0 ? (
+                                <span className="text-gray-500">-</span>
+                              ) : (
+                                formatNumber(item.completedWatchCount)
+                              )}
+                            </td>
+                            <td className="px-5 py-4 text-sm">
+                              {item.totalWatchCount === 0 ? (
+                                <span className="text-gray-500">-</span>
+                              ) : (
+                                <RateBadge value={formatRate(item.completionRate)} />
+                              )}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+          </SectionCard>
+        </>
+      )}
+    </div>
+  );
+};
+
+const SectionCard = ({ children }: { children: React.ReactNode }) => {
+  return <section className="rounded-2xl bg-gray-900 p-6">{children}</section>;
+};
+
+const KpiCard = ({
+  icon,
+  title,
+  value,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  value: string;
+  description: string;
+}) => {
+  return (
+    <div className="rounded-2xl bg-gray-900 p-5">
+      <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-gray-800 text-primary">
+        {icon}
+      </div>
+      <p className="text-sm text-gray-400">{title}</p>
+      <p className="mt-2 text-3xl font-bold text-white">{value}</p>
+      <p className="mt-2 text-xs text-gray-500">{description}</p>
+    </div>
+  );
+};
+
+const InsightBanner = ({
+  topViewTag,
+  topViewValue,
+  topBookmarkTag,
+  topBookmarkValue,
+  topCompletionTag,
+  topCompletionValue,
+}: {
+  topViewTag?: string;
+  topViewValue: string;
+  topBookmarkTag?: string;
+  topBookmarkValue: string;
+  topCompletionTag?: string;
+  topCompletionValue: string;
+}) => {
+  return (
+    <section className="grid grid-cols-1 gap-3 xl:grid-cols-3">
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/70 px-5 py-4">
+        <p className="text-xs uppercase tracking-wide text-gray-400">Top View</p>
+        <p className="mt-2 text-base font-semibold text-white">
+          {topViewTag ?? "-"}
+        </p>
+        <p className="mt-1 text-sm text-primary">{topViewValue}</p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/70 px-5 py-4">
+        <p className="text-xs uppercase tracking-wide text-gray-400">
+          Top Bookmark Rate
+        </p>
+        <p className="mt-2 text-base font-semibold text-white">
+          {topBookmarkTag ?? "-"}
+        </p>
+        <p className="mt-1 text-sm text-primary">{topBookmarkValue}</p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/70 px-5 py-4">
+        <p className="text-xs uppercase tracking-wide text-gray-400">
+          Top Completion Rate
+        </p>
+        <p className="mt-2 text-base font-semibold text-white">
+          {topCompletionTag ?? "-"}
+        </p>
+        <p className="mt-1 text-sm text-primary">{topCompletionValue}</p>
+      </div>
+    </section>
+  );
+};
+
+const TopRankingTabs = ({
+  activeTab,
+  onChange,
+  items,
+}: {
+  activeTab: RankingTabKey;
+  onChange: (tab: RankingTabKey) => void;
+  items: { tagName: string; value: string }[];
+}) => {
+  const tabs: { key: RankingTabKey; label: string }[] = [
+    { key: "views", label: "조회수 TOP 5" },
+    { key: "bookmarkRate", label: "북마크율 TOP 5" },
+    { key: "completionRate", label: "완료율 TOP 5" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-5 flex flex-wrap gap-2">
+        {tabs.map((tab) => {
+          const isActive = activeTab === tab.key;
+
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onChange(tab.key)}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+                isActive
+                  ? "bg-primary text-black"
+                  : "bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
+        {items.map((item, index) => (
+          <div
+            key={`${activeTab}-${item.tagName}`}
+            className="rounded-2xl border border-gray-800 bg-gray-800/70 px-4 py-4"
+          >
+            <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary/20 text-sm font-bold text-primary">
+              {index + 1}
+            </div>
+            <p className="truncate text-sm text-gray-400">{item.tagName}</p>
+            <p className="mt-2 text-lg font-bold text-white">{item.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const RateBadge = ({ value }: { value: string }) => {
+  return (
+    <span className="inline-flex rounded-full bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
+      {value}
+    </span>
+  );
+};
+
+const formatNumber = (value: number) => value.toLocaleString();
+
+const formatRate = (value: number) => `${(value * 100).toFixed(2)}%`;
+
+const formatCompactNumber = (value: number) => {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+  return value.toString();
+};
+
+export default Statistics;

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,3 +1,4 @@
+// adminService.ts - 관리자 관련 API 서비스
 import apiClient from "./apiClient";
 import type {
   AdminUser,
@@ -5,6 +6,18 @@ import type {
   AdminUserListParams,
   PageResponse,
 } from "@/types";
+
+export interface HomeTagStatItem {
+  statDate: string;
+  tagId: number;
+  tagName: string;
+  totalViewCount: number;
+  totalBookmarkCount: number;
+  bookmarkRate: number;
+  totalWatchCount: number;
+  completedWatchCount: number;
+  completionRate: number;
+}
 
 export const adminService = {
   // 사용자 목록 조회
@@ -19,5 +32,13 @@ export const adminService = {
   getUserDetail: async (userId: number): Promise<AdminUserDetail> => {
     const response = await apiClient.get(`/admin/users/${userId}`);
     return response.data;
+  },
+
+  // 홈 노출 태그(priority=1) 통계 조회
+  getHomeTagStats: async (statDate: string): Promise<HomeTagStatItem[]> => {
+    const response = await apiClient.get("/admin/stats/home-tags", {
+      params: { statDate },
+    });
+    return response.data.data;
   },
 };


### PR DESCRIPTION
## 관리자 통계 페이지

### 변경 목적
관리자가 홈 노출(priority=1) 태그의 성과를 한눈에 파악하고 분석할 수 있도록 통계/분석 페이지를 개선했습니다.


### 변경 사항
- [기능 추가] 홈 노출 태그 성과 대시보드 구현
- [기능 추가] KPI 카드(총 조회수, 총 북마크, 평균 북마크율, 평균 완료율) 표시
- [기능 추가] 태그별 조회수 상위 차트(BarChart) 시각화
- [기능 추가] 조회수 / 북마크율 / 완료율 기준 Top5 태그 랭킹 표시
- [기능 추가] 태그 성과 상세 테이블 구현
- [기능 추가] 태그 검색 기능 추가
- [기능 추가] 최소 시청 수 필터 기능 추가
- [기능 추가] 정렬 기준(조회수/북마크/북마크율/시청/완료/완료율) 선택 기능 추가
- [구조 개선] 통계 페이지 코드를 `Statistics.tsx`로 분리하여 AdminPage.tsx의 책임 분리
- [UI 개선] KPI → 태그 비교 → 상세 데이터 흐름으로 통계 화면 구성

### 기타
- Recharts를 사용하여 태그 조회수 차트를 시각화했습니다.

<img width="1551" height="559" alt="image" src="https://github.com/user-attachments/assets/0314cb74-43e4-4838-942a-a14b1d53f46e" />
<img width="1545" height="782" alt="image" src="https://github.com/user-attachments/assets/92f2e9ed-6712-4a3f-aa29-8ad51b1ef450" />

